### PR TITLE
central statsd support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@
 
 FROM tarampampam/node:10.10-alpine
 
-RUN git clone git://github.com/etsy/statsd.git /usr/local/src/statsd
+RUN git clone git@github.com:statsd/statsd.git /usr/local/src/statsd
 
 ADD ./etc/config.js ./etc/default/statsd.js
 
 ADD ./etc/start_statsd.sh ./etc/default/start_statsd.sh
+
+WORKDIR /usr/local/src/statsd/
+RUN npm install generic-pool@2.2.0
 
 ENV GRAPHITE_GLOBAL_PREFIX stats
 ENV GRAPHITE_LEGACY_NAMESPACE true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM tarampampam/node:10.10-alpine
 
-RUN git clone git@github.com:statsd/statsd.git /usr/local/src/statsd
+RUN git clone git://github.com/etsy/statsd.git /usr/local/src/statsd
 
 ADD ./etc/config.js ./etc/default/statsd.js
 

--- a/etc/config.js
+++ b/etc/config.js
@@ -102,7 +102,7 @@ Optional Variables:
                          changes. The default is true. Set this to false to disable.
 */
 (function() {
-    var suffix = process.env.INSTANCE_ID;
+    var suffix = process.env.HOST_NAME;
     if(typeof suffix != 'undefined' && suffix && suffix != '') {
       suffix = '.' + suffix;
     } else {
@@ -117,7 +117,8 @@ Optional Variables:
         dumpMessages: process.env.STATSD_DUMP_MSG == "true",
         debug: process.env.STATSD_DEBUG == "true",
         flushInterval: parseInt(process.env.STATSD_FLUSH_INTERVAL),
-        backends: [ "./backends/graphite" ],
+        backends: [ "./backends/graphite", "./backends/repeater" ],
+        repeater: [ { host: process.env.REPEATER_HOST, port: 8125 } ],
         deleteCounters: true,
         deleteGauges: true,
         percentThreshold: [90, 99],

--- a/etc/start_statsd.sh
+++ b/etc/start_statsd.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-instance_id=$(wget 169.254.169.254/latest/meta-data/instance-id -q -O -)
-echo "Using instance id: "
-echo $instance_id
-export INSTANCE_ID=$instance_id
-INSTANCE_ID=$instance_id node /usr/local/src/statsd/stats.js /etc/default/statsd.js
+instance_hostname=$(wget 169.254.169.254/latest/meta-data/hostname -q -O - | cut -d '.' -f1)
+echo "Using hostname: $instance_hostname"
+export HOST_NAME=$instance_hostname
+HOST_NAME=$instance_hostname node /usr/local/src/statsd/stats.js /etc/default/statsd.js


### PR DESCRIPTION
* Central statsd via repeater backend 
* use container hostname for statsd global prefix
